### PR TITLE
Simplify ForecastGraph by removing sequential view toggle

### DIFF
--- a/frontend/src/pages/SpecificForecast.jsx
+++ b/frontend/src/pages/SpecificForecast.jsx
@@ -109,9 +109,8 @@ function SpecificForecast() {
     
   const sortedPoints = [...filteredPoints].sort((a, b) => new Date(a.created) - new Date(b.created));
   
-  // Use a 4-hour minimum time window between points
-  const chartData = filteredPoints && filteredPoints.length > 0 ? 
-    prepareChartData(filteredPoints, isMultiUserMode, false, 0, users) : null;
+  const chartData = filteredPoints && filteredPoints.length > 0 ?
+    prepareChartData(filteredPoints, isMultiUserMode, 0, users) : null;
   
   const chartOptions = {
     title: {
@@ -122,8 +121,7 @@ function SpecificForecast() {
         min: 0,
         max: 1,
       }
-    },
-    useSequential: false // Use date-based x-axis
+    }
   };
 
   return (

--- a/frontend/src/utils/chartDataUtils.jsx
+++ b/frontend/src/utils/chartDataUtils.jsx
@@ -10,198 +10,117 @@ export const lineColors = [
 ];
 
 /**
- * Transforms user forecast points into chart-ready data
- * Supporting both sequential and time-based views
+ * Transforms user forecast points into chart-ready data (time-based view)
  * @param {Array} pointsData - Array of forecast points from multiple users
  * @param {Boolean} multiUser - Whether to process as multi-user or single user
- * @param {Boolean} useSequential - Whether to use sequential numbering (#1, #2) or dates
  * @param {Number} minTimeWindowHours - Minimum hours between points (to avoid clustering)
+ * @param {Array} users - Array of user objects for name lookup
  * @returns {Object} Formatted data for recharts
  */
-export const prepareChartData = (pointsData, multiUser = true, useSequential = true, minTimeWindowHours = 0, users = []) => {
+export const prepareChartData = (pointsData, multiUser = true, minTimeWindowHours = 0, users = []) => {
   if (!pointsData || pointsData.length === 0) return null;
-  
-  // Format date consistently for display
+
   const formatDate = (dateString) => {
     const date = new Date(dateString);
     return `${date.getMonth() + 1}/${date.getDate()}`;
   };
-  
-  console.log('Chart data preparation', { 
-    pointsCount: pointsData.length, 
-    multiUser,
-    useSequential,
-    userIds: [...new Set(pointsData.map(p => p.user_id))]
-  });
-  
+
   // Check if the data is in the simplified format from the ordered endpoint
   const isSimplifiedFormat = pointsData.length > 0 && 'created_at' in pointsData[0];
-  
-  // Filter points within a minimum time window (rather than by day)
-  // This keeps more detail when forecasts are close together
+
+  // Get the date field based on format
+  const getDateField = (point) => isSimplifiedFormat ? point.created_at : point.created;
+
+  // Filter points within a minimum time window
   const filterPointsByTimeWindow = (points) => {
-    if (points.length <= 1) return points;
-    
+    if (points.length <= 1 || minTimeWindowHours === 0) {
+      return [...points].sort((a, b) => new Date(getDateField(a)) - new Date(getDateField(b)));
+    }
+
+    const minTimeWindowMs = minTimeWindowHours * 60 * 60 * 1000;
+    const sortedPoints = [...points].sort((a, b) => new Date(getDateField(a)) - new Date(getDateField(b)));
+
     let filteredPoints = [];
     let lastTimestamp = null;
-    const minTimeWindowMs = minTimeWindowHours * 60 * 60 * 1000;
-    
-    // Sort chronologically first
-    const sortedPoints = [...points].sort((a, b) => {
-      const dateA = new Date(isSimplifiedFormat ? a.created_at : a.created);
-      const dateB = new Date(isSimplifiedFormat ? b.created_at : b.created);
-      return dateA - dateB;
-    });
-    
-    // Keep points that are separated by at least minTimeWindowMs
+
     sortedPoints.forEach(point => {
-      const timestamp = new Date(isSimplifiedFormat ? point.created_at : point.created).getTime();
-      
+      const timestamp = new Date(getDateField(point)).getTime();
       if (lastTimestamp === null || (timestamp - lastTimestamp) >= minTimeWindowMs) {
         filteredPoints.push(point);
         lastTimestamp = timestamp;
       }
     });
-    
+
     // Always include the most recent point
     const lastPoint = sortedPoints[sortedPoints.length - 1];
-    const lastPointTime = new Date(isSimplifiedFormat ? lastPoint.created_at : lastPoint.created).getTime();
-    
-    if (filteredPoints.length === 0 || 
-        lastPointTime !== new Date(isSimplifiedFormat ? 
-          filteredPoints[filteredPoints.length - 1].created_at : 
-          filteredPoints[filteredPoints.length - 1].created).getTime()) {
+    const lastPointTime = new Date(getDateField(lastPoint)).getTime();
+    if (filteredPoints.length === 0 ||
+        lastPointTime !== new Date(getDateField(filteredPoints[filteredPoints.length - 1])).getTime()) {
       filteredPoints.push(lastPoint);
     }
-    
+
     return filteredPoints;
   };
-  
-  // Multi-user mode
+
   if (multiUser) {
     // Group points by user
     const userPointsMap = {};
-    
     pointsData.forEach(point => {
       const userId = point.user_id || 'anonymous';
       if (!userPointsMap[userId]) {
         userPointsMap[userId] = [];
       }
-      userPointsMap[userId].push({...point});
+      userPointsMap[userId].push({ ...point });
     });
-    
+
     // Create a dataset for each user
     const datasets = Object.entries(userPointsMap).map(([userId, userPoints], index) => {
-      // Apply time window filtering if not using sequential numbering
-      let sortedUserPoints = useSequential ? 
-        [...userPoints].sort((a, b) => {
-          const dateA = new Date(isSimplifiedFormat ? a.created_at : a.created);
-          const dateB = new Date(isSimplifiedFormat ? b.created_at : b.created);
-          return dateA - dateB;
-        }) : 
-        filterPointsByTimeWindow(userPoints);
-      
-      // Get user name or use a generic name
+      const sortedUserPoints = filterPointsByTimeWindow(userPoints);
       const user = users.find(u => u.id === parseInt(userId, 10));
       const userName = user ? user.username : (sortedUserPoints[0]?.username || `User ${userId}`);
-      
+
       return {
         label: userName,
         data: sortedUserPoints.map(point => point.point_forecast),
-        // Store full date objects for the x-axis scaling
-        timestamps: sortedUserPoints.map(point => new Date(isSimplifiedFormat ? point.created_at : point.created).getTime()),
-        // Store formatted dates for display
-        dates: sortedUserPoints.map(point => formatDate(isSimplifiedFormat ? point.created_at : point.created)),
+        timestamps: sortedUserPoints.map(point => new Date(getDateField(point)).getTime()),
+        dates: sortedUserPoints.map(point => formatDate(getDateField(point))),
         fill: false,
         borderColor: lineColors[index % lineColors.length],
         tension: 0.1
       };
     });
-    
-    if (useSequential) {
-      // Find the dataset with the most points to use for labels
-      const maxPointsDataset = datasets.reduce((max, ds) => 
-        ds.data.length > max.data.length ? ds : max, 
-        { data: [] }
-      );
-      
-      // Generate numeric labels (1, 2, 3, ...) matching the length of the longest dataset
-      const labels = Array.from({ length: maxPointsDataset.data.length }, (_, i) => `#${i+1}`);
-      
-      return {
-        labels,
-        datasets,
-        _isSequenced: true
-      };
-    } else {
-      // For date-based x-axis, we need to collect all timestamps from all users
-      let allTimestamps = [];
-      datasets.forEach(dataset => {
-        allTimestamps = [...allTimestamps, ...dataset.timestamps];
-      });
-      
-      // Get unique timestamps and sort
-      const uniqueTimestamps = [...new Set(allTimestamps)].sort((a, b) => a - b);
-      
-      // Create labels from timestamps
-      const labels = uniqueTimestamps.map(ts => formatDate(new Date(ts)));
-      
-      // Create actual data structure with proper timestamp range
-      // No need for additional padding - this will be handled by the chart component
-      return {
-        labels,
-        datasets,
-        _isSequenced: false,
-        _timestamps: uniqueTimestamps
-      };
-    }
+
+    // Collect all timestamps from all users
+    let allTimestamps = [];
+    datasets.forEach(dataset => {
+      allTimestamps = [...allTimestamps, ...dataset.timestamps];
+    });
+
+    const uniqueTimestamps = [...new Set(allTimestamps)].sort((a, b) => a - b);
+    const labels = uniqueTimestamps.map(ts => formatDate(new Date(ts)));
+
+    return {
+      labels,
+      datasets,
+      _timestamps: uniqueTimestamps
+    };
   }
-  
+
   // Single user mode
-  // Apply time window filtering if not using sequential mode
-  let sortedPoints = useSequential ? 
-    [...pointsData].sort((a, b) => {
-      const dateA = new Date(isSimplifiedFormat ? a.created_at : a.created);
-      const dateB = new Date(isSimplifiedFormat ? b.created_at : b.created);
-      return dateA - dateB;
-    }) : 
-    filterPointsByTimeWindow(pointsData);
-  
-  const timestamps = sortedPoints.map(point => 
-    new Date(isSimplifiedFormat ? point.created_at : point.created).getTime()
-  );
-  
-  if (useSequential) {
-    return {
-      // For x-axis labels, use simple sequential numbers
-      labels: sortedPoints.map((_, i) => `#${i+1}`),
-      datasets: [{
-        label: 'Prediction',
-        data: sortedPoints.map(point => point.point_forecast),
-        // Store dates for tooltips - handle both formats
-        dates: sortedPoints.map(point => formatDate(isSimplifiedFormat ? point.created_at : point.created)),
-        fill: false,
-        borderColor: lineColors[0],
-        tension: 0.1
-      }],
-      _isSequenced: true
-    };
-  } else {
-    // Build data structure for time-based view
-    // No need for padding - that's handled by the chart component
-    return {
-      labels: sortedPoints.map(point => formatDate(isSimplifiedFormat ? point.created_at : point.created)),
-      datasets: [{
-        label: 'Prediction',
-        data: sortedPoints.map(point => point.point_forecast),
-        timestamps: timestamps,
-        dates: sortedPoints.map(point => formatDate(isSimplifiedFormat ? point.created_at : point.created)),
-        fill: false,
-        borderColor: lineColors[0],
-        tension: 0.1
-      }],
-      _isSequenced: false,
-      _timestamps: timestamps
-    };
-  }
+  const sortedPoints = filterPointsByTimeWindow(pointsData);
+  const timestamps = sortedPoints.map(point => new Date(getDateField(point)).getTime());
+
+  return {
+    labels: sortedPoints.map(point => formatDate(getDateField(point))),
+    datasets: [{
+      label: 'Prediction',
+      data: sortedPoints.map(point => point.point_forecast),
+      timestamps,
+      dates: sortedPoints.map(point => formatDate(getDateField(point))),
+      fill: false,
+      borderColor: lineColors[0],
+      tension: 0.1
+    }],
+    _timestamps: timestamps
+  };
 };


### PR DESCRIPTION
## Summary
Remove the sequential vs. time-based view toggle from ForecastGraph. Time-based is what users actually want for viewing predictions over time.

## Changes
- **ForecastGraph.jsx**: Removed toggle state, switch UI, and sequential view logic
- **chartDataUtils.jsx**: Removed `useSequential` parameter and all sequential-related code paths
- **SpecificForecast.jsx**: Updated `prepareChartData` call to match new signature

## Line Reduction
- ForecastGraph: 310 → 195 lines (**-115 lines**)
- chartDataUtils: 207 → 127 lines (**-80 lines**)
- **Total: ~200 lines removed**

## Before/After
**Before**: Toggle switch in graph header to switch between "Sequential" (#1, #2, #3...) and "Time" (date-based) x-axis views

**After**: Always time-based x-axis showing actual dates when predictions were made

## Test plan
- [x] Verify forecast graph displays with time-based x-axis
- [x] Verify multi-user mode shows all users' predictions over time
- [x] Verify tooltips show correct dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)