### PR TITLE
Add calibration endpoints and chart component

### DIFF
--- a/backend/internal/handlers/calibration_handler.go
+++ b/backend/internal/handlers/calibration_handler.go
@@ -1,0 +1,102 @@
+package handlers
+
+import (
+	"backend/internal/logger"
+	"backend/internal/models"
+	"backend/internal/services"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type CalibrationHandler struct {
+	service *services.CalibrationService
+}
+
+func NewCalibrationHandler(s *services.CalibrationService) *CalibrationHandler {
+	return &CalibrationHandler{service: s}
+}
+
+func (h *CalibrationHandler) GetCalibration(w http.ResponseWriter, r *http.Request) {
+	log := logger.FromContext(r.Context())
+
+	filters, err := parseCalibrationFilters(r)
+	if err != nil {
+		log.Error("invalid filter parameter", slog.String("error", err.Error()))
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	log.Info("getting calibration data", slog.Any("filters", filters))
+	data, err := h.service.GetCalibrationData(r.Context(), filters)
+	if err != nil {
+		log.Error("failed to get calibration data", slog.String("error", err.Error()))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	respondJSON(w, http.StatusOK, data)
+}
+
+func (h *CalibrationHandler) GetCalibrationByUsers(w http.ResponseWriter, r *http.Request) {
+	log := logger.FromContext(r.Context())
+
+	filters, err := parseCalibrationFilters(r)
+	if err != nil {
+		log.Error("invalid filter parameter", slog.String("error", err.Error()))
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	log.Info("getting calibration data by users", slog.Any("filters", filters))
+	data, err := h.service.GetCalibrationDataByUsers(r.Context(), filters)
+	if err != nil {
+		log.Error("failed to get calibration data by users", slog.String("error", err.Error()))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	respondJSON(w, http.StatusOK, data)
+}
+
+func parseCalibrationFilters(r *http.Request) (models.CalibrationFilters, error) {
+	queryParams := r.URL.Query()
+	var filters models.CalibrationFilters
+
+	userIDStr := queryParams.Get("user_id")
+	if userIDStr != "" {
+		userID, err := strconv.ParseInt(userIDStr, 10, 64)
+		if err != nil {
+			return filters, err
+		}
+		filters.UserID = &userID
+	}
+
+	categoryStr := queryParams.Get("category")
+	if categoryStr != "" {
+		category := strings.ToLower(categoryStr)
+		filters.Category = &category
+	}
+
+	startDateStr := queryParams.Get("start_date")
+	if startDateStr != "" {
+		startDate, err := time.Parse(time.RFC3339, startDateStr)
+		if err != nil {
+			return filters, err
+		}
+		filters.StartDate = &startDate
+	}
+
+	endDateStr := queryParams.Get("end_date")
+	if endDateStr != "" {
+		endDate, err := time.Parse(time.RFC3339, endDateStr)
+		if err != nil {
+			return filters, err
+		}
+		filters.EndDate = &endDate
+	}
+
+	return filters, nil
+}

--- a/backend/internal/models/calibration.go
+++ b/backend/internal/models/calibration.go
@@ -1,0 +1,35 @@
+package models
+
+import "time"
+
+// CalibrationBucket represents a single probability bucket with calibration data
+type CalibrationBucket struct {
+	BucketStart     float64 `json:"bucket_start"`
+	BucketEnd       float64 `json:"bucket_end"`
+	PredictionCount int     `json:"prediction_count"`
+	AvgPrediction   float64 `json:"avg_prediction"`
+	ActualRate      float64 `json:"actual_rate"`
+}
+
+// CalibrationData contains overall calibration data
+type CalibrationData struct {
+	Buckets          []CalibrationBucket `json:"buckets"`
+	TotalPredictions int                 `json:"total_predictions"`
+	TotalForecasts   int                 `json:"total_forecasts"`
+}
+
+// UserCalibrationData contains per-user calibration data
+type UserCalibrationData struct {
+	UserID           int64               `json:"user_id"`
+	Buckets          []CalibrationBucket `json:"buckets"`
+	TotalPredictions int                 `json:"total_predictions"`
+	TotalForecasts   int                 `json:"total_forecasts"`
+}
+
+// CalibrationFilters contains filter options for calibration queries
+type CalibrationFilters struct {
+	UserID    *int64
+	Category  *string
+	StartDate *time.Time
+	EndDate   *time.Time
+}

--- a/backend/internal/repository/calibration_repository.go
+++ b/backend/internal/repository/calibration_repository.go
@@ -1,0 +1,196 @@
+package repository
+
+import (
+	"backend/internal/database"
+	"backend/internal/logger"
+	"backend/internal/models"
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+// CalibrationRepository defines the interface for calibration data operations
+type CalibrationRepository interface {
+	GetCalibrationData(ctx context.Context, filters models.CalibrationFilters) (*models.CalibrationData, error)
+	GetCalibrationDataByUsers(ctx context.Context, filters models.CalibrationFilters) ([]models.UserCalibrationData, error)
+}
+
+// PostgresCalibrationRepository implements the CalibrationRepository interface
+type PostgresCalibrationRepository struct {
+	db *database.DB
+}
+
+// NewCalibrationRepository creates a new PostgresCalibrationRepository instance
+func NewCalibrationRepository(db *database.DB) CalibrationRepository {
+	return &PostgresCalibrationRepository{db: db}
+}
+
+func buildCalibrationBaseQuery(filters models.CalibrationFilters, groupByUser bool) (string, []any) {
+	args := []any{}
+	argsCounter := 1
+
+	whereConditions := []string{"f.resolution IN ('0', '1')"}
+
+	if filters.UserID != nil {
+		whereConditions = append(whereConditions, fmt.Sprintf("p.user_id = $%d", argsCounter))
+		args = append(args, *filters.UserID)
+		argsCounter++
+	}
+	if filters.Category != nil {
+		whereConditions = append(whereConditions, fmt.Sprintf("lower(f.category) LIKE $%d", argsCounter))
+		args = append(args, "%"+*filters.Category+"%")
+		argsCounter++
+	}
+	if filters.StartDate != nil {
+		whereConditions = append(whereConditions, fmt.Sprintf("p.created >= $%d", argsCounter))
+		args = append(args, *filters.StartDate)
+		argsCounter++
+	}
+	if filters.EndDate != nil {
+		whereConditions = append(whereConditions, fmt.Sprintf("p.created <= $%d", argsCounter))
+		args = append(args, *filters.EndDate)
+		argsCounter++
+	}
+
+	userIDSelect := ""
+	userIDGroupBy := ""
+	if groupByUser {
+		userIDSelect = "p.user_id,"
+		userIDGroupBy = "p.user_id,"
+	}
+
+	query := fmt.Sprintf(`
+WITH point_outcomes AS (
+    SELECT
+        p.point_forecast,
+        p.user_id,
+        p.forecast_id,
+        CASE WHEN f.resolution = '1' THEN 1 ELSE 0 END as outcome
+    FROM points p
+    INNER JOIN forecasts f ON p.forecast_id = f.id
+    WHERE %s
+)
+SELECT
+    %s
+    FLOOR(point_forecast * 10) / 10 as bucket_start,
+    COUNT(*) as prediction_count,
+    AVG(point_forecast) as avg_prediction,
+    AVG(outcome::float) as actual_rate,
+    COUNT(DISTINCT forecast_id) as forecast_count
+FROM point_outcomes
+GROUP BY %s FLOOR(point_forecast * 10) / 10
+ORDER BY %s bucket_start
+`, strings.Join(whereConditions, " AND "), userIDSelect, userIDGroupBy, userIDSelect)
+
+	return query, args
+}
+
+func (r *PostgresCalibrationRepository) GetCalibrationData(ctx context.Context, filters models.CalibrationFilters) (*models.CalibrationData, error) {
+	log := logger.FromContext(ctx)
+
+	query, args := buildCalibrationBaseQuery(filters, false)
+
+	start := time.Now()
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		log.Error("failed to execute calibration query", slog.String("error", err.Error()))
+		return nil, err
+	}
+	log.Info("executed calibration query", slog.Duration("duration", time.Since(start)))
+	defer rows.Close()
+
+	var buckets []models.CalibrationBucket
+	var totalPredictions, totalForecasts int
+
+	for rows.Next() {
+		var bucket models.CalibrationBucket
+		var forecastCount int
+		if err := rows.Scan(
+			&bucket.BucketStart,
+			&bucket.PredictionCount,
+			&bucket.AvgPrediction,
+			&bucket.ActualRate,
+			&forecastCount,
+		); err != nil {
+			log.Error("failed to scan calibration row", slog.String("error", err.Error()))
+			return nil, err
+		}
+		bucket.BucketEnd = bucket.BucketStart + 0.1
+		buckets = append(buckets, bucket)
+		totalPredictions += bucket.PredictionCount
+		totalForecasts += forecastCount
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	log.Info("calibration query results", slog.Int("bucket_count", len(buckets)), slog.Int("total_predictions", totalPredictions))
+	return &models.CalibrationData{
+		Buckets:          buckets,
+		TotalPredictions: totalPredictions,
+		TotalForecasts:   totalForecasts,
+	}, nil
+}
+
+func (r *PostgresCalibrationRepository) GetCalibrationDataByUsers(ctx context.Context, filters models.CalibrationFilters) ([]models.UserCalibrationData, error) {
+	log := logger.FromContext(ctx)
+
+	query, args := buildCalibrationBaseQuery(filters, true)
+
+	start := time.Now()
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		log.Error("failed to execute calibration by users query", slog.String("error", err.Error()))
+		return nil, err
+	}
+	log.Info("executed calibration by users query", slog.Duration("duration", time.Since(start)))
+	defer rows.Close()
+
+	// Map to collect buckets per user
+	userDataMap := make(map[int64]*models.UserCalibrationData)
+
+	for rows.Next() {
+		var userID int64
+		var bucket models.CalibrationBucket
+		var forecastCount int
+		if err := rows.Scan(
+			&userID,
+			&bucket.BucketStart,
+			&bucket.PredictionCount,
+			&bucket.AvgPrediction,
+			&bucket.ActualRate,
+			&forecastCount,
+		); err != nil {
+			log.Error("failed to scan calibration by users row", slog.String("error", err.Error()))
+			return nil, err
+		}
+		bucket.BucketEnd = bucket.BucketStart + 0.1
+
+		if _, exists := userDataMap[userID]; !exists {
+			userDataMap[userID] = &models.UserCalibrationData{
+				UserID:  userID,
+				Buckets: []models.CalibrationBucket{},
+			}
+		}
+		userData := userDataMap[userID]
+		userData.Buckets = append(userData.Buckets, bucket)
+		userData.TotalPredictions += bucket.PredictionCount
+		userData.TotalForecasts += forecastCount
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Convert map to slice
+	result := make([]models.UserCalibrationData, 0, len(userDataMap))
+	for _, userData := range userDataMap {
+		result = append(result, *userData)
+	}
+
+	log.Info("calibration by users query results", slog.Int("user_count", len(result)))
+	return result, nil
+}

--- a/backend/internal/routes/routes.go
+++ b/backend/internal/routes/routes.go
@@ -13,6 +13,7 @@ type Handlers struct {
 	ForecastPoint *handlers.ForecastPointHandler
 	User          *handlers.UserHandler
 	Score         *handlers.ScoreHandler
+	Calibration   *handlers.CalibrationHandler
 }
 
 type Services struct {
@@ -20,6 +21,7 @@ type Services struct {
 	ForecastPoint *services.ForecastPointService
 	User          *services.UserService
 	Score         *services.ScoreService
+	Calibration   *services.CalibrationService
 }
 
 type Repositories struct {
@@ -27,6 +29,7 @@ type Repositories struct {
 	ForecastPoint repository.ForecastPointRepository
 	User          repository.UserRepository
 	Score         repository.ScoreRepository
+	Calibration   repository.CalibrationRepository
 }
 
 func Setup(mux *http.ServeMux, handlers *Handlers) {
@@ -63,6 +66,10 @@ func setupPublicRoutes(mux *http.ServeMux, handlers *Handlers) {
 	mux.HandleFunc("POST /users", handlers.User.CreateUser)
 	mux.HandleFunc("POST /users/login", handlers.User.Login)
 	// mux.HandleFunc("POST /users/reset-password", handlers.User.AdminResetPassword)
+
+	// calibration
+	mux.HandleFunc("GET /calibration", handlers.Calibration.GetCalibration)
+	mux.HandleFunc("GET /calibration/users", handlers.Calibration.GetCalibrationByUsers)
 }
 
 func setupProtectedRoutes(mux *http.ServeMux, handlers *Handlers) {

--- a/backend/internal/services/calibration.go
+++ b/backend/internal/services/calibration.go
@@ -1,0 +1,90 @@
+package services
+
+import (
+	"backend/internal/cache"
+	"backend/internal/logger"
+	"backend/internal/models"
+	"backend/internal/repository"
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+type CalibrationService struct {
+	repo  repository.CalibrationRepository
+	cache *cache.Cache
+}
+
+func NewCalibrationService(repo repository.CalibrationRepository, cache *cache.Cache) *CalibrationService {
+	return &CalibrationService{repo: repo, cache: cache}
+}
+
+func (s *CalibrationService) GetCalibrationData(ctx context.Context, filters models.CalibrationFilters) (*models.CalibrationData, error) {
+	log := logger.FromContext(ctx)
+	log.Info("getting calibration data", slog.Any("filters", filters))
+
+	// Build cache key
+	dateRangeKey, cacheable := getCacheableDateRangeKey(filters.StartDate, filters.EndDate)
+	if cacheable {
+		cacheKey := s.buildCacheKey("calibration", filters, dateRangeKey)
+		if cachedData, found := s.cache.Get(cacheKey); found {
+			log.Info("cache hit", slog.String("cache_key", cacheKey), slog.String("cache_type", "calibration data"))
+			return cachedData.(*models.CalibrationData), nil
+		}
+		log.Info("cache miss", slog.String("cache_key", cacheKey), slog.String("cache_type", "calibration data"))
+
+		data, err := s.repo.GetCalibrationData(ctx, filters)
+		if err != nil {
+			log.Error("failed to get calibration data", slog.String("error", err.Error()))
+			return nil, err
+		}
+		s.cache.Set(cacheKey, data)
+		return data, nil
+	}
+
+	// Custom date range - don't cache
+	log.Info("custom date range - skipping cache")
+	return s.repo.GetCalibrationData(ctx, filters)
+}
+
+func (s *CalibrationService) GetCalibrationDataByUsers(ctx context.Context, filters models.CalibrationFilters) ([]models.UserCalibrationData, error) {
+	log := logger.FromContext(ctx)
+	log.Info("getting calibration data by users", slog.Any("filters", filters))
+
+	// Build cache key
+	dateRangeKey, cacheable := getCacheableDateRangeKey(filters.StartDate, filters.EndDate)
+	if cacheable {
+		cacheKey := s.buildCacheKey("calibration:users", filters, dateRangeKey)
+		if cachedData, found := s.cache.Get(cacheKey); found {
+			log.Info("cache hit", slog.String("cache_key", cacheKey), slog.String("cache_type", "calibration data by users"))
+			return cachedData.([]models.UserCalibrationData), nil
+		}
+		log.Info("cache miss", slog.String("cache_key", cacheKey), slog.String("cache_type", "calibration data by users"))
+
+		data, err := s.repo.GetCalibrationDataByUsers(ctx, filters)
+		if err != nil {
+			log.Error("failed to get calibration data by users", slog.String("error", err.Error()))
+			return nil, err
+		}
+		s.cache.Set(cacheKey, data)
+		return data, nil
+	}
+
+	// Custom date range - don't cache
+	log.Info("custom date range - skipping cache")
+	return s.repo.GetCalibrationDataByUsers(ctx, filters)
+}
+
+func (s *CalibrationService) buildCacheKey(prefix string, filters models.CalibrationFilters, dateRangeKey string) string {
+	key := prefix
+
+	if filters.UserID != nil {
+		key = fmt.Sprintf("%s:user:%d", key, *filters.UserID)
+	}
+	if filters.Category != nil {
+		key = fmt.Sprintf("%s:category:%s", key, *filters.Category)
+	}
+	key = fmt.Sprintf("%s:%s", key, dateRangeKey)
+
+	return key
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -55,6 +55,7 @@ func main() {
 		ForecastPoint: repository.NewForecastPointRepository(db),
 		User:          repository.NewUserRepository(db),
 		Score:         repository.NewScoreRepository(db),
+		Calibration:   repository.NewCalibrationRepository(db),
 	}
 
 	cache := cache.NewCache()
@@ -64,6 +65,7 @@ func main() {
 		ForecastPoint: services.NewForecastPointService(repositories.ForecastPoint, repositories.Forecast, cache),
 		User:          services.NewUserService(repositories.User, cache),
 		Score:         services.NewScoreService(repositories.Score, cache),
+		Calibration:   services.NewCalibrationService(repositories.Calibration, cache),
 	}
 
 	handlers := &routes.Handlers{
@@ -71,6 +73,7 @@ func main() {
 		ForecastPoint: handlers.NewForecastPointHandler(services.ForecastPoint),
 		User:          handlers.NewUserHandler(services.User),
 		Score:         handlers.NewScoreHandler(services.Score),
+		Calibration:   handlers.NewCalibrationHandler(services.Calibration),
 	}
 
 	mux := http.NewServeMux()

--- a/frontend/src/components/CalibrationChart.jsx
+++ b/frontend/src/components/CalibrationChart.jsx
@@ -1,0 +1,218 @@
+import React from 'react';
+import {
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+  Cell
+} from 'recharts';
+import {
+  Paper,
+  Box,
+  Typography,
+  useTheme,
+  CircularProgress,
+  Alert
+} from '@mui/material';
+import { useCalibration } from '../services/hooks/useCalibration';
+
+function CalibrationChart({ userId = 'all', dateRange = null, category = null }) {
+  const theme = useTheme();
+
+  const { calibration, loading, error } = useCalibration({
+    type: 'overall',
+    userId,
+    category,
+    dateRange,
+  });
+
+  // Transform data for the scatter chart
+  const chartData = calibration?.buckets?.map(bucket => ({
+    avgPrediction: bucket.avg_prediction * 100,
+    actualRate: bucket.actual_rate * 100,
+    predictionCount: bucket.prediction_count,
+    bucketStart: bucket.bucket_start * 100,
+    bucketEnd: bucket.bucket_end * 100,
+  })) || [];
+
+  // Perfect calibration line data (0,0) to (100,100)
+  const perfectCalibrationData = [
+    { x: 0, y: 0 },
+    { x: 100, y: 100 }
+  ];
+
+  const CustomTooltip = ({ active, payload }) => {
+    if (active && payload && payload.length) {
+      const data = payload[0].payload;
+      return (
+        <Box
+          sx={{
+            backgroundColor: theme.palette.background.paper,
+            border: `1px solid ${theme.palette.divider}`,
+            borderRadius: 1,
+            p: 1.5,
+            boxShadow: theme.shadows[2],
+          }}
+        >
+          <Typography variant="body2" sx={{ fontWeight: 600, mb: 0.5 }}>
+            Bucket: {data.bucketStart.toFixed(0)}% - {data.bucketEnd.toFixed(0)}%
+          </Typography>
+          <Typography variant="body2">
+            Avg Prediction: {data.avgPrediction.toFixed(1)}%
+          </Typography>
+          <Typography variant="body2">
+            Actual Rate: {data.actualRate.toFixed(1)}%
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Predictions: {data.predictionCount}
+          </Typography>
+        </Box>
+      );
+    }
+    return null;
+  };
+
+  if (loading) {
+    return (
+      <Paper
+        elevation={0}
+        sx={{
+          p: 2.5,
+          bgcolor: 'background.paper',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: 300,
+        }}
+      >
+        <CircularProgress />
+      </Paper>
+    );
+  }
+
+  if (error) {
+    return (
+      <Paper
+        elevation={0}
+        sx={{
+          p: 2.5,
+          bgcolor: 'background.paper',
+          height: '100%',
+        }}
+      >
+        <Alert severity="error">{error}</Alert>
+      </Paper>
+    );
+  }
+
+  if (!chartData.length) {
+    return (
+      <Paper
+        elevation={0}
+        sx={{
+          p: 2.5,
+          bgcolor: 'background.paper',
+          height: '100%',
+        }}
+      >
+        <Typography variant="h6" gutterBottom>
+          Calibration
+        </Typography>
+        <Typography color="text.secondary">
+          No calibration data available for the selected filters.
+        </Typography>
+      </Paper>
+    );
+  }
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 2.5,
+        bgcolor: 'background.paper',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+        <Typography variant="h6">
+          Calibration
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          {calibration?.total_predictions} predictions across {calibration?.total_forecasts} forecasts
+        </Typography>
+      </Box>
+
+      <Box sx={{ flex: 1, minHeight: 250 }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <ScatterChart
+            margin={{ top: 10, right: 20, left: 0, bottom: 20 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke={theme.palette.divider} />
+            <XAxis
+              type="number"
+              dataKey="avgPrediction"
+              domain={[0, 100]}
+              tickFormatter={(value) => `${value}%`}
+              tick={{ fill: theme.palette.text.primary, fontSize: 12 }}
+              label={{
+                value: 'Predicted Probability',
+                position: 'bottom',
+                offset: 0,
+                style: { fill: theme.palette.text.secondary, fontSize: 12 }
+              }}
+            />
+            <YAxis
+              type="number"
+              dataKey="actualRate"
+              domain={[0, 100]}
+              tickFormatter={(value) => `${value}%`}
+              tick={{ fill: theme.palette.text.primary, fontSize: 12 }}
+              label={{
+                value: 'Actual Rate',
+                angle: -90,
+                position: 'insideLeft',
+                style: { fill: theme.palette.text.secondary, fontSize: 12, textAnchor: 'middle' }
+              }}
+            />
+            <Tooltip content={<CustomTooltip />} />
+            {/* Perfect calibration reference line */}
+            <ReferenceLine
+              segment={[{ x: 0, y: 0 }, { x: 100, y: 100 }]}
+              stroke={theme.palette.text.disabled}
+              strokeDasharray="5 5"
+              strokeWidth={2}
+            />
+            <Scatter
+              name="Calibration"
+              data={chartData}
+              fill={theme.palette.primary.main}
+            >
+              {chartData.map((entry, index) => (
+                <Cell
+                  key={`cell-${index}`}
+                  fill={theme.palette.primary.main}
+                  // Size based on prediction count (log scale for better visualization)
+                  r={Math.max(6, Math.min(20, 4 + Math.log10(entry.predictionCount + 1) * 6))}
+                />
+              ))}
+            </Scatter>
+          </ScatterChart>
+        </ResponsiveContainer>
+      </Box>
+
+      <Typography variant="caption" color="text.secondary" sx={{ mt: 1, textAlign: 'center' }}>
+        Points on the dashed line indicate perfect calibration. Point size reflects prediction count.
+      </Typography>
+    </Paper>
+  );
+}
+
+export default CalibrationChart;

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -5,6 +5,7 @@ import UserLeaderboard from '../components/UserLeaderboard';
 import LatestForecastPoints from '../components/LatestForecastPoints';
 import DateRangeSelector from '../components/DateRangeSelector';
 import UserSelector from '../components/UserSelector';
+import CalibrationChart from '../components/CalibrationChart';
 import { DATE_RANGE_OPTIONS } from '../services/api/scoreService';
 import {
   Container,
@@ -64,6 +65,10 @@ function HomePage() {
             <UserLeaderboard dateRange={dateRange} />
           </Grid2>
         </Grid2>
+
+        <Box sx={{ mt: 4 }}>
+          <CalibrationChart userId={selectedUserId} dateRange={dateRange} />
+        </Box>
       </Box>
 
       <Box component="section" sx={{ mb: 6 }}>

--- a/frontend/src/services/api/calibrationService.jsx
+++ b/frontend/src/services/api/calibrationService.jsx
@@ -1,0 +1,89 @@
+import { API_BASE_URL } from './index';
+import { DATE_RANGE_OPTIONS, getStartDateForRange } from './scoreService';
+
+/**
+ * Fetch overall calibration data
+ * @param {Object} options
+ * @param {string|number} options.user_id - Filter by user ID
+ * @param {string} options.category - Filter by category
+ * @param {string} options.dateRange - Predefined date range (from DATE_RANGE_OPTIONS)
+ * @param {Date|string} options.start_date - Custom start date
+ * @param {Date|string} options.end_date - Custom end date
+ */
+export const fetchCalibrationData = async ({
+  user_id,
+  category,
+  dateRange,
+  start_date,
+  end_date,
+} = {}) => {
+  const params = new URLSearchParams();
+  if (user_id && user_id !== 'all') params.append('user_id', user_id);
+  if (category) params.append('category', category);
+
+  // Handle date range - either predefined option or custom dates
+  if (dateRange && dateRange !== DATE_RANGE_OPTIONS.ALL_TIME) {
+    const startDate = getStartDateForRange(dateRange);
+    if (startDate) {
+      params.append('start_date', startDate.toISOString());
+    }
+  } else if (start_date) {
+    params.append('start_date', start_date instanceof Date ? start_date.toISOString() : start_date);
+    if (end_date) {
+      params.append('end_date', end_date instanceof Date ? end_date.toISOString() : end_date);
+    }
+  }
+
+  const response = await fetch(`${API_BASE_URL}/calibration?${params.toString()}`, {
+    method: 'GET',
+    headers: { 'Accept': 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Error fetching calibration data: ${response.status}`);
+  }
+
+  return response.json();
+};
+
+/**
+ * Fetch calibration data grouped by users
+ * @param {Object} options
+ * @param {string} options.category - Filter by category
+ * @param {string} options.dateRange - Predefined date range (from DATE_RANGE_OPTIONS)
+ * @param {Date|string} options.start_date - Custom start date
+ * @param {Date|string} options.end_date - Custom end date
+ */
+export const fetchCalibrationDataByUsers = async ({
+  category,
+  dateRange,
+  start_date,
+  end_date,
+} = {}) => {
+  const params = new URLSearchParams();
+  if (category) params.append('category', category);
+
+  // Handle date range - either predefined option or custom dates
+  if (dateRange && dateRange !== DATE_RANGE_OPTIONS.ALL_TIME) {
+    const startDate = getStartDateForRange(dateRange);
+    if (startDate) {
+      params.append('start_date', startDate.toISOString());
+    }
+  } else if (start_date) {
+    params.append('start_date', start_date instanceof Date ? start_date.toISOString() : start_date);
+    if (end_date) {
+      params.append('end_date', end_date instanceof Date ? end_date.toISOString() : end_date);
+    }
+  }
+
+  const response = await fetch(`${API_BASE_URL}/calibration/users?${params.toString()}`, {
+    method: 'GET',
+    headers: { 'Accept': 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Error fetching calibration data by users: ${response.status}`);
+  }
+
+  return response.json();
+};

--- a/frontend/src/services/api/index.jsx
+++ b/frontend/src/services/api/index.jsx
@@ -2,6 +2,7 @@ import * as forecastService from './forecastService';
 import * as pointsService from './pointsService';
 import * as scoreService from './scoreService';
 import * as userService from './userService';
+import * as calibrationService from './calibrationService';
 
 // You can also define shared constants here
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080';
@@ -10,5 +11,6 @@ export {
   forecastService,
   pointsService,
   scoreService,
-  userService
+  userService,
+  calibrationService
 };

--- a/frontend/src/services/hooks/useCalibration.jsx
+++ b/frontend/src/services/hooks/useCalibration.jsx
@@ -1,0 +1,94 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  fetchCalibrationData,
+  fetchCalibrationDataByUsers,
+} from '../api/calibrationService';
+
+/**
+ * Hook for fetching calibration data.
+ *
+ * @param {Object} options
+ * @param {'overall' | 'by-users'} options.type - Type of calibration data to fetch
+ * @param {string|number|null} options.userId - User ID filter (use 'all' or null for all users)
+ * @param {string|null} options.category - Category filter
+ * @param {string|null} options.dateRange - Date range filter
+ * @param {boolean} options.shouldFetch - Whether to fetch data (default: true)
+ *
+ * Usage examples:
+ *
+ * // Overall calibration data
+ * useCalibration({ type: 'overall' })
+ *
+ * // Calibration for a specific user
+ * useCalibration({ type: 'overall', userId: 1 })
+ *
+ * // Calibration by users (for comparison)
+ * useCalibration({ type: 'by-users' })
+ */
+export const useCalibration = ({
+  type = 'overall',
+  userId = null,
+  category = null,
+  dateRange = null,
+  shouldFetch = true,
+} = {}) => {
+  const [calibration, setCalibration] = useState(null);
+  const [loading, setLoading] = useState(shouldFetch);
+  const [error, setError] = useState(null);
+
+  // Normalize userId - treat 'all' as null
+  const normalizedUserId = userId === 'all' ? null : userId;
+
+  const fetchData = useCallback(async () => {
+    if (!shouldFetch) {
+      setLoading(false);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+      let data;
+
+      switch (type) {
+        case 'overall':
+          data = await fetchCalibrationData({
+            user_id: normalizedUserId,
+            category,
+            dateRange,
+          });
+          break;
+
+        case 'by-users':
+          data = await fetchCalibrationDataByUsers({
+            category,
+            dateRange,
+          });
+          break;
+
+        default:
+          console.warn(`Unknown calibration type: ${type}`);
+          data = null;
+      }
+
+      setCalibration(data);
+    } catch (err) {
+      console.error(`Error fetching ${type} calibration:`, err);
+      setError(err.message || 'Failed to load calibration data');
+      setCalibration(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [type, normalizedUserId, category, dateRange, shouldFetch]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return {
+    calibration,
+    loading,
+    error,
+    refetch: fetchData,
+  };
+};


### PR DESCRIPTION
## Summary
- Add backend endpoints (`GET /calibration` and `GET /calibration/users`) to return calibration data showing how well-calibrated predictions are across probability buckets
- Add CalibrationChart component to the home page that displays predicted probability vs actual outcome rate

## Changes

**Backend:**
- New `CalibrationBucket`, `CalibrationData`, `UserCalibrationData`, and `CalibrationFilters` models
- `CalibrationRepository` with SQL query joining `points` with `forecasts` to calculate calibration metrics
- `CalibrationService` with caching support
- `CalibrationHandler` with query parameter parsing (user_id, category, start_date, end_date)

**Frontend:**
- `calibrationService.jsx` - API functions for fetching calibration data
- `useCalibration.jsx` - React hook for data fetching
- `CalibrationChart.jsx` - Scatter chart with perfect calibration reference line
- Updated HomePage to display calibration chart below scores section

## Test plan
- [x] Build backend: `cd backend && go build ./...`
- [x] Build frontend: `cd frontend && npm run build`
- [x] Test endpoint: `curl http://localhost:8080/calibration`
- [x] Test with filters: `curl http://localhost:8080/calibration?user_id=1`
- [x] Verify chart renders on home page with calibration data

🤖 Generated with [Claude Code](https://claude.com/claude-code)